### PR TITLE
chore: :recycle: update for ModLoader 6.2.0

### DIFF
--- a/root/mods-unpacked/Darkly77-Brotils/manifest.json
+++ b/root/mods-unpacked/Darkly77-Brotils/manifest.json
@@ -1,17 +1,41 @@
 {
 	"name": "Brotils",
 	"namespace": "Darkly77",
-	"version_number": "1.1.1",
+	"version_number": "1.1.2",
 	"description": "Extends Utils.gd with more helpers",
 	"website_url": "https://github.com/BrotatoMods/Brotils",
-	"dependencies": [],
+	"dependencies": [
+
+	],
 	"extra": {
 		"godot": {
-			"incompatibilities": [],
-			"authors": ["Darkly77"],
-			"compatible_mod_loader_version": ["3.0.0"],
-			"compatible_game_version": ["0.6.1.6"],
-			"config_defaults": {}
+			"authors": [
+				"Darkly77",
+				"KANA"
+			],
+			"optional_dependencies": [
+
+			],
+			"compatible_game_version": [
+				"1.0.1.3"
+			],
+			"compatible_mod_loader_version": [
+				"6.2.0"
+			],
+			"incompatibilities": [
+
+			],
+			"load_before": [
+
+			],
+			"tags": [
+
+			],
+			"config_schema": {
+
+			},
+			"description_rich": "",
+			"image": null
 		}
 	}
 }

--- a/root/mods-unpacked/Darkly77-Brotils/mod_main.gd
+++ b/root/mods-unpacked/Darkly77-Brotils/mod_main.gd
@@ -2,7 +2,7 @@ extends Node
 
 const BROTILS_LOG = "Darkly77-Brotils"
 
-func _init(modLoader = ModLoader):
+func _init():
 	ModLoaderLog.info("Init", BROTILS_LOG)
 	ModLoaderMod.install_script_extension("res://mods-unpacked/Darkly77-Brotils/extensions/singletons/utils.gd")
 


### PR DESCRIPTION
Removed the ModLoader parameter from `mod_main` `_init()`